### PR TITLE
change python doc links from v2 to v3

### DIFF
--- a/courses/neural_network/python1.html
+++ b/courses/neural_network/python1.html
@@ -12528,7 +12528,7 @@ rga
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p>You can find a list of all string methods in the <a href="https://docs.python.org/2/library/stdtypes.html#string-methods">documentation</a>.</p>
+<p>You can find a list of all string methods in the <a href="https://docs.python.org/3/library/stdtypes.html#string-methods">documentation</a>.</p>
 
 </div>
 </div>

--- a/courses/neural_network/python1.ipynb
+++ b/courses/neural_network/python1.ipynb
@@ -511,7 +511,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can find a list of all string methods in the [documentation](https://docs.python.org/2/library/stdtypes.html#string-methods)."
+    "You can find a list of all string methods in the [documentation](https://docs.python.org/3/library/stdtypes.html#string-methods)."
    ]
   },
   {

--- a/courses/neural_network/python2.html
+++ b/courses/neural_network/python2.html
@@ -12316,7 +12316,7 @@ monkey
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p>As usual, you can find all the gory details about lists in the <a href="https://docs.python.org/2/tutorial/datastructures.html#more-on-lists">documentation</a>.</p>
+<p>As usual, you can find all the gory details about lists in the <a href="https://docs.python.org/3/tutorial/datastructures.html#more-on-lists">documentation</a>.</p>
 
 </div>
 </div>
@@ -12823,7 +12823,7 @@ True
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p>You can find all you need to know about dictionaries in the <a href="https://docs.python.org/2/library/stdtypes.html#dict">documentation</a>.</p>
+<p>You can find all you need to know about dictionaries in the <a href="https://docs.python.org/3/library/stdtypes.html#dict">documentation</a>.</p>
 
 </div>
 </div>

--- a/courses/neural_network/python2.ipynb
+++ b/courses/neural_network/python2.ipynb
@@ -365,7 +365,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As usual, you can find all the gory details about lists in the [documentation](https://docs.python.org/2/tutorial/datastructures.html#more-on-lists)."
+    "As usual, you can find all the gory details about lists in the [documentation](https://docs.python.org/3/tutorial/datastructures.html#more-on-lists)."
    ]
   },
   {
@@ -704,7 +704,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can find all you need to know about dictionaries in the [documentation](https://docs.python.org/2/library/stdtypes.html#dict)."
+    "You can find all you need to know about dictionaries in the [documentation](https://docs.python.org/3/library/stdtypes.html#dict)."
    ]
   },
   {


### PR DESCRIPTION
Thanks for making these excellent materials available! Just a small set of updates for the two Python Crash course files for the neural network course, to update the python docs link to v3.